### PR TITLE
Migrate preferences to androidX, notification prefs only for < Oreo

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -26,12 +26,9 @@
     <PreferenceCategory
         android:key="@string/pref_key_notifications"
         android:title="@string/pref_notifications">
-        <RingtonePreference
+        <Preference
             android:key="@string/pref_key_notification_ringtone"
             android:title="@string/pref_notification_ringtone_title"
-            android:ringtoneType="notification"
-            android:showDefault="true"
-            android:showSilent="true"
             android:defaultValue="content://settings/system/notification_sound"
             android:persistent="true"/>
 


### PR DESCRIPTION
Migrating preferences from (now deprecated) framework preferences to jetpack
preferences.

RingtonePreference doesn't exist anymore as a pre-built, so:
- we roll our own
- and also notice that on Oreo+, notification preferences are pointless. So we
  use any already set preferences to set up the channels (for the improbable case
  that a device that has quickfit already installed updates the OS to Oreo), and
  stop showing the preferences on Oreo+.